### PR TITLE
Tạo constants (AppColors, AppTypography, AppSpacing, AppEndpoints)

### DIFF
--- a/lib/core/constants/app_colors.dart
+++ b/lib/core/constants/app_colors.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+class AppColors {
+  AppColors._();
+
+  // Backgrounds
+  static const Color background = Color(0xFF0F0F0F);
+  static const Color surface = Color(0xFF1A1A1A);
+  static const Color surfaceVariant = Color(0xFF282828);
+
+  // Brand
+  static const Color primary = Color(0xFFFF0033);
+  static const Color onPrimary = Color(0xFFFFFFFF);
+
+  // Text
+  static const Color text = Color(0xFFFFFFFF);
+  static const Color textSecondary = Color(0xFFAAAAAA);
+  static const Color subtext = Color(0xFF717171);
+
+  // Utility
+  static const Color divider = Color(0xFF2A2A2A);
+  static const Color error = Color(0xFFCF6679);
+  static const Color icon = Color(0xFFFFFFFF);
+  static const Color iconMuted = Color(0xFF717171);
+}

--- a/lib/core/constants/app_endpoints.dart
+++ b/lib/core/constants/app_endpoints.dart
@@ -1,0 +1,12 @@
+class AppEndpoints {
+  AppEndpoints._();
+
+  static const String _youtubeBase = 'https://www.googleapis.com/youtube/v3';
+
+  static const String youtubeSearch = '$_youtubeBase/search';
+  static const String youtubeVideos = '$_youtubeBase/videos';
+
+  static const String lrclibBase = 'https://lrclib.net/api';
+  static const String lrclibSearch = '$lrclibBase/search';
+  static const String lrclibGet = '$lrclibBase/get';
+}

--- a/lib/core/constants/app_spacing.dart
+++ b/lib/core/constants/app_spacing.dart
@@ -1,0 +1,10 @@
+class AppSpacing {
+  AppSpacing._();
+
+  static const double xs = 4;
+  static const double sm = 8;
+  static const double md = 16;
+  static const double lg = 24;
+  static const double xl = 32;
+  static const double xxl = 48;
+}

--- a/lib/core/constants/app_typography.dart
+++ b/lib/core/constants/app_typography.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+import 'package:ymusic/core/constants/app_colors.dart';
+
+class AppTypography {
+  AppTypography._();
+
+  static const TextStyle h1 = TextStyle(
+    fontSize: 28,
+    fontWeight: FontWeight.bold,
+    color: AppColors.text,
+    height: 1.3,
+  );
+
+  static const TextStyle h2 = TextStyle(
+    fontSize: 22,
+    fontWeight: FontWeight.w600,
+    color: AppColors.text,
+    height: 1.35,
+  );
+
+  static const TextStyle h3 = TextStyle(
+    fontSize: 18,
+    fontWeight: FontWeight.w600,
+    color: AppColors.text,
+    height: 1.4,
+  );
+
+  static const TextStyle body = TextStyle(
+    fontSize: 14,
+    fontWeight: FontWeight.normal,
+    color: AppColors.text,
+    height: 1.5,
+  );
+
+  static const TextStyle caption = TextStyle(
+    fontSize: 12,
+    fontWeight: FontWeight.normal,
+    color: AppColors.textSecondary,
+    height: 1.4,
+  );
+
+  static const TextStyle label = TextStyle(
+    fontSize: 11,
+    fontWeight: FontWeight.w500,
+    color: AppColors.subtext,
+    letterSpacing: 0.4,
+    height: 1.3,
+  );
+}

--- a/lib/core/constants/constants.dart
+++ b/lib/core/constants/constants.dart
@@ -1,0 +1,4 @@
+export 'package:ymusic/core/constants/app_colors.dart';
+export 'package:ymusic/core/constants/app_endpoints.dart';
+export 'package:ymusic/core/constants/app_spacing.dart';
+export 'package:ymusic/core/constants/app_typography.dart';


### PR DESCRIPTION
## Summary
- Tạo đầy đủ constants cho dark theme, typography, spacing, và API endpoints
- Tất cả constants là `static const`, không hardcode trong widget

## Designs
- N/A (không có wireframe cho task này)

## Changes
- `lib/core/constants/app_colors.dart` — AppColors (background, surface, primary, text, error...)
- `lib/core/constants/app_typography.dart` — AppTypography (h1, h2, h3, body, caption, label)
- `lib/core/constants/app_spacing.dart` — AppSpacing (xs, sm, md, lg, xl, xxl)
- `lib/core/constants/app_endpoints.dart` — AppEndpoints (YouTube Data API v3, lrclib.net)
- `lib/core/constants/constants.dart` — barrel export

## Issue
Closes #15