### PR TITLE
feat(infra): Firestore Security Rules – /users/{uid}/** owner-only access

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,9 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{uid}/{document=**} {
+      allow read, write: if request.auth != null && request.auth.uid == uid;
+    }
+  }
+}

--- a/specs/issues/2.3-firestore-security-rules.md
+++ b/specs/issues/2.3-firestore-security-rules.md
@@ -1,0 +1,68 @@
+## **Status:**
+- Review: Approved
+- PR: Merged
+
+## Metadata
+- **Title:** Firestore Security Rules: `/users/{uid}/**` read/write chỉ cho authenticated owner
+- **Phase:** Phase 2 – Core Infrastructure (Shared, Minimal)
+- **GitHub Issue:** #40
+
+---
+
+## Description
+
+Viết Firestore Security Rules đảm bảo mỗi user chỉ có thể đọc/ghi data của chính mình tại path `/users/{uid}/**`.
+
+Mục tiêu:
+- Ngăn user A truy cập data của user B
+- Chỉ authenticated user mới có quyền đọc/ghi
+- Rules áp dụng cho toàn bộ sub-collections: `liked_songs`, `history`, `playlists`, `subscribed_podcasts`, `preferences`
+
+---
+
+## Design
+- N/A (infrastructure layer, không có UI)
+
+---
+
+## Acceptance Criteria
+- [ ] Rule từ chối unauthenticated requests (chưa đăng nhập)
+- [ ] Rule cho phép authenticated user đọc/ghi `users/{uid}/**` khi `request.auth.uid == uid`
+- [ ] Rule từ chối authenticated user đọc/ghi path của user khác
+- [ ] Rules được viết trong file `firestore.rules` tại root project
+- [ ] Verify bằng Firebase Emulator hoặc Rules Playground trên Firebase Console
+
+---
+
+## Implementation Checklist
+- [ ] `[🤖]` Tạo file `firestore.rules` tại root project với nội dung rules
+- [ ] `[🤖]` Đảm bảo rule dùng wildcard `{uid}` khớp với `request.auth.uid`
+- [ ] `[🤖]` Cover path `/users/{uid}` và toàn bộ sub-paths `/{document=**}`
+- [ ] `[👤]` Mở Firebase Console → Firestore → Rules → paste nội dung file → Publish
+- [ ] `[👤]` Verify rules bằng Rules Playground: test unauthenticated (deny), test owner (allow), test other user (deny)
+
+---
+
+## Notes
+
+- Scope: chỉ Firestore rules — không liên quan đến Firebase Storage hay Realtime Database
+- Rule pattern tối giản, không over-engineer:
+  ```
+  rules_version = '2';
+  service cloud.firestore {
+    match /databases/{database}/documents {
+      match /users/{uid}/{document=**} {
+        allow read, write: if request.auth != null && request.auth.uid == uid;
+      }
+    }
+  }
+  ```
+- `[👤]` deploy thủ công lên Firebase Console — không dùng Firebase CLI trong phase này
+- Dependency của: tất cả các phase dùng Firestore (6.x LikedSongs, 5.1 History, 7.x Playlist, 10.x Sync, 11.5 Podcast progress)
+
+---
+
+## Screenshots
+| Screen Name | Navigation Steps | Expected State |
+|---|---|---|
+| N/A | N/A | N/A |


### PR DESCRIPTION
## Summary
- Thêm file `firestore.rules` tại root project
- Restrict read/write `/users/{uid}/**` chỉ cho authenticated owner (`request.auth.uid == uid`)
- Deny unauthenticated requests và cross-user access trên toàn bộ sub-collections

## Designs
- N/A (infrastructure layer, không có UI)

## Issue
Closes #40

<!-- slack-thread-ts: 1773651665.684629 -->