### PR TITLE
feat(core): i18n infrastructure - intl + AppLocalizations + ARB files

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,0 +1,6 @@
+arb-dir: l10n
+template-arb-file: en.arb
+output-localization-file: app_localizations.dart
+output-dir: lib/l10n
+nullable-getter: false
+synthetic-package: false

--- a/l10n/en.arb
+++ b/l10n/en.arb
@@ -1,0 +1,93 @@
+{
+  "@@locale": "en",
+
+  "appName": "YMusic",
+  "@appName": {
+    "description": "The name of the application"
+  },
+
+  "actionSearch": "Search",
+  "@actionSearch": {
+    "description": "Search action label"
+  },
+
+  "actionCancel": "Cancel",
+  "@actionCancel": {
+    "description": "Cancel action label"
+  },
+
+  "actionConfirm": "Confirm",
+  "@actionConfirm": {
+    "description": "Confirm action label"
+  },
+
+  "actionRetry": "Retry",
+  "@actionRetry": {
+    "description": "Retry action label"
+  },
+
+  "actionDelete": "Delete",
+  "@actionDelete": {
+    "description": "Delete action label"
+  },
+
+  "actionSave": "Save",
+  "@actionSave": {
+    "description": "Save action label"
+  },
+
+  "actionClose": "Close",
+  "@actionClose": {
+    "description": "Close action label"
+  },
+
+  "actionPlay": "Play",
+  "@actionPlay": {
+    "description": "Play action label"
+  },
+
+  "actionPause": "Pause",
+  "@actionPause": {
+    "description": "Pause action label"
+  },
+
+  "errorNetwork": "Network error. Please check your connection.",
+  "@errorNetwork": {
+    "description": "Network error message"
+  },
+
+  "errorUnknown": "An unknown error occurred. Please try again.",
+  "@errorUnknown": {
+    "description": "Unknown error message"
+  },
+
+  "errorUnauthorized": "You are not authorized. Please sign in again.",
+  "@errorUnauthorized": {
+    "description": "Unauthorized error message"
+  },
+
+  "errorNotFound": "The requested resource was not found.",
+  "@errorNotFound": {
+    "description": "Not found error message"
+  },
+
+  "errorTimeout": "The request timed out. Please try again.",
+  "@errorTimeout": {
+    "description": "Timeout error message"
+  },
+
+  "labelLoading": "Loading...",
+  "@labelLoading": {
+    "description": "Loading state label"
+  },
+
+  "labelNoResults": "No results found.",
+  "@labelNoResults": {
+    "description": "Empty results label"
+  },
+
+  "labelNoInternet": "No internet connection.",
+  "@labelNoInternet": {
+    "description": "No internet label"
+  }
+}

--- a/l10n/vi.arb
+++ b/l10n/vi.arb
@@ -1,0 +1,39 @@
+{
+  "@@locale": "vi",
+
+  "appName": "YMusic",
+
+  "actionSearch": "Tìm kiếm",
+
+  "actionCancel": "Hủy",
+
+  "actionConfirm": "Xác nhận",
+
+  "actionRetry": "Thử lại",
+
+  "actionDelete": "Xóa",
+
+  "actionSave": "Lưu",
+
+  "actionClose": "Đóng",
+
+  "actionPlay": "Phát",
+
+  "actionPause": "Tạm dừng",
+
+  "errorNetwork": "Lỗi mạng. Vui lòng kiểm tra kết nối của bạn.",
+
+  "errorUnknown": "Đã xảy ra lỗi không xác định. Vui lòng thử lại.",
+
+  "errorUnauthorized": "Bạn không có quyền truy cập. Vui lòng đăng nhập lại.",
+
+  "errorNotFound": "Không tìm thấy tài nguyên yêu cầu.",
+
+  "errorTimeout": "Yêu cầu đã hết thời gian. Vui lòng thử lại.",
+
+  "labelLoading": "Đang tải...",
+
+  "labelNoResults": "Không tìm thấy kết quả.",
+
+  "labelNoInternet": "Không có kết nối internet."
+}

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:ymusic/core/constants/app_strings.dart';
 import 'package:ymusic/core/router/app_router.dart';
 import 'package:ymusic/core/theme/app_theme.dart';
+import 'package:ymusic/l10n/app_localizations.dart';
+
+final localeProvider = StateProvider<Locale>((ref) => const Locale('en'));
 
 class YMusicApp extends ConsumerWidget {
   const YMusicApp({super.key});
@@ -10,14 +13,25 @@ class YMusicApp extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final router = ref.watch(routerProvider);
+    final locale = ref.watch(localeProvider);
 
     return MaterialApp.router(
-      title: AppStrings.title,
       debugShowCheckedModeBanner: false,
       theme: AppTheme.light,
       darkTheme: AppTheme.dark,
       themeMode: ThemeMode.dark,
       routerConfig: router,
+      locale: locale,
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [
+        Locale('en'),
+        Locale('vi'),
+      ],
     );
   }
 }

--- a/lib/core/extensions/l10n_extension.dart
+++ b/lib/core/extensions/l10n_extension.dart
@@ -1,0 +1,6 @@
+import 'package:flutter/widgets.dart';
+import 'package:ymusic/l10n/app_localizations.dart';
+
+extension L10nExtension on BuildContext {
+  AppLocalizations get l10n => AppLocalizations.of(this);
+}

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1,0 +1,237 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/intl.dart' as intl;
+
+import 'app_localizations_en.dart';
+import 'app_localizations_vi.dart';
+
+// ignore_for_file: type=lint
+
+/// Callers can lookup localized strings with an instance of AppLocalizations
+/// returned by `AppLocalizations.of(context)`.
+///
+/// Applications need to include `AppLocalizations.delegate()` in their app's
+/// `localizationDelegates` list, and the locales they support in the app's
+/// `supportedLocales` list. For example:
+///
+/// ```dart
+/// import 'l10n/app_localizations.dart';
+///
+/// return MaterialApp(
+///   localizationsDelegates: AppLocalizations.localizationsDelegates,
+///   supportedLocales: AppLocalizations.supportedLocales,
+///   home: MyApplicationHome(),
+/// );
+/// ```
+///
+/// ## Update pubspec.yaml
+///
+/// Please make sure to update your pubspec.yaml to include the following
+/// packages:
+///
+/// ```yaml
+/// dependencies:
+///   # Internationalization support.
+///   flutter_localizations:
+///     sdk: flutter
+///   intl: any # Use the pinned version from flutter_localizations
+///
+///   # Rest of dependencies
+/// ```
+///
+/// ## iOS Applications
+///
+/// iOS applications define key application metadata, including supported
+/// locales, in an Info.plist file that is built into the application bundle.
+/// To configure the locales supported by your app, you’ll need to edit this
+/// file.
+///
+/// First, open your project’s ios/Runner.xcworkspace Xcode workspace file.
+/// Then, in the Project Navigator, open the Info.plist file under the Runner
+/// project’s Runner folder.
+///
+/// Next, select the Information Property List item, select Add Item from the
+/// Editor menu, then select Localizations from the pop-up menu.
+///
+/// Select and expand the newly-created Localizations item then, for each
+/// locale your application supports, add a new item and select the locale
+/// you wish to add from the pop-up menu in the Value field. This list should
+/// be consistent with the languages listed in the AppLocalizations.supportedLocales
+/// property.
+abstract class AppLocalizations {
+  AppLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+
+  final String localeName;
+
+  static AppLocalizations of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
+  }
+
+  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
+
+  /// A list of this localizations delegate along with the default localizations
+  /// delegates.
+  ///
+  /// Returns a list of localizations delegates containing this delegate along with
+  /// GlobalMaterialLocalizations.delegate, GlobalCupertinoLocalizations.delegate,
+  /// and GlobalWidgetsLocalizations.delegate.
+  ///
+  /// Additional delegates can be added by appending to this list in
+  /// MaterialApp. This list does not have to be used at all if a custom list
+  /// of delegates is preferred or required.
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
+
+  /// A list of this localizations delegate's supported locales.
+  static const List<Locale> supportedLocales = <Locale>[
+    Locale('en'),
+    Locale('vi')
+  ];
+
+  /// The name of the application
+  ///
+  /// In en, this message translates to:
+  /// **'YMusic'**
+  String get appName;
+
+  /// Search action label
+  ///
+  /// In en, this message translates to:
+  /// **'Search'**
+  String get actionSearch;
+
+  /// Cancel action label
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel'**
+  String get actionCancel;
+
+  /// Confirm action label
+  ///
+  /// In en, this message translates to:
+  /// **'Confirm'**
+  String get actionConfirm;
+
+  /// Retry action label
+  ///
+  /// In en, this message translates to:
+  /// **'Retry'**
+  String get actionRetry;
+
+  /// Delete action label
+  ///
+  /// In en, this message translates to:
+  /// **'Delete'**
+  String get actionDelete;
+
+  /// Save action label
+  ///
+  /// In en, this message translates to:
+  /// **'Save'**
+  String get actionSave;
+
+  /// Close action label
+  ///
+  /// In en, this message translates to:
+  /// **'Close'**
+  String get actionClose;
+
+  /// Play action label
+  ///
+  /// In en, this message translates to:
+  /// **'Play'**
+  String get actionPlay;
+
+  /// Pause action label
+  ///
+  /// In en, this message translates to:
+  /// **'Pause'**
+  String get actionPause;
+
+  /// Network error message
+  ///
+  /// In en, this message translates to:
+  /// **'Network error. Please check your connection.'**
+  String get errorNetwork;
+
+  /// Unknown error message
+  ///
+  /// In en, this message translates to:
+  /// **'An unknown error occurred. Please try again.'**
+  String get errorUnknown;
+
+  /// Unauthorized error message
+  ///
+  /// In en, this message translates to:
+  /// **'You are not authorized. Please sign in again.'**
+  String get errorUnauthorized;
+
+  /// Not found error message
+  ///
+  /// In en, this message translates to:
+  /// **'The requested resource was not found.'**
+  String get errorNotFound;
+
+  /// Timeout error message
+  ///
+  /// In en, this message translates to:
+  /// **'The request timed out. Please try again.'**
+  String get errorTimeout;
+
+  /// Loading state label
+  ///
+  /// In en, this message translates to:
+  /// **'Loading...'**
+  String get labelLoading;
+
+  /// Empty results label
+  ///
+  /// In en, this message translates to:
+  /// **'No results found.'**
+  String get labelNoResults;
+
+  /// No internet label
+  ///
+  /// In en, this message translates to:
+  /// **'No internet connection.'**
+  String get labelNoInternet;
+}
+
+class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  Future<AppLocalizations> load(Locale locale) {
+    return SynchronousFuture<AppLocalizations>(lookupAppLocalizations(locale));
+  }
+
+  @override
+  bool isSupported(Locale locale) => <String>['en', 'vi'].contains(locale.languageCode);
+
+  @override
+  bool shouldReload(_AppLocalizationsDelegate old) => false;
+}
+
+AppLocalizations lookupAppLocalizations(Locale locale) {
+
+
+  // Lookup logic when only language code is specified.
+  switch (locale.languageCode) {
+    case 'en': return AppLocalizationsEn();
+    case 'vi': return AppLocalizationsVi();
+  }
+
+  throw FlutterError(
+    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.'
+  );
+}

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1,0 +1,64 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for English (`en`).
+class AppLocalizationsEn extends AppLocalizations {
+  AppLocalizationsEn([String locale = 'en']) : super(locale);
+
+  @override
+  String get appName => 'YMusic';
+
+  @override
+  String get actionSearch => 'Search';
+
+  @override
+  String get actionCancel => 'Cancel';
+
+  @override
+  String get actionConfirm => 'Confirm';
+
+  @override
+  String get actionRetry => 'Retry';
+
+  @override
+  String get actionDelete => 'Delete';
+
+  @override
+  String get actionSave => 'Save';
+
+  @override
+  String get actionClose => 'Close';
+
+  @override
+  String get actionPlay => 'Play';
+
+  @override
+  String get actionPause => 'Pause';
+
+  @override
+  String get errorNetwork => 'Network error. Please check your connection.';
+
+  @override
+  String get errorUnknown => 'An unknown error occurred. Please try again.';
+
+  @override
+  String get errorUnauthorized => 'You are not authorized. Please sign in again.';
+
+  @override
+  String get errorNotFound => 'The requested resource was not found.';
+
+  @override
+  String get errorTimeout => 'The request timed out. Please try again.';
+
+  @override
+  String get labelLoading => 'Loading...';
+
+  @override
+  String get labelNoResults => 'No results found.';
+
+  @override
+  String get labelNoInternet => 'No internet connection.';
+}

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -1,0 +1,64 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Vietnamese (`vi`).
+class AppLocalizationsVi extends AppLocalizations {
+  AppLocalizationsVi([String locale = 'vi']) : super(locale);
+
+  @override
+  String get appName => 'YMusic';
+
+  @override
+  String get actionSearch => 'Tìm kiếm';
+
+  @override
+  String get actionCancel => 'Hủy';
+
+  @override
+  String get actionConfirm => 'Xác nhận';
+
+  @override
+  String get actionRetry => 'Thử lại';
+
+  @override
+  String get actionDelete => 'Xóa';
+
+  @override
+  String get actionSave => 'Lưu';
+
+  @override
+  String get actionClose => 'Đóng';
+
+  @override
+  String get actionPlay => 'Phát';
+
+  @override
+  String get actionPause => 'Tạm dừng';
+
+  @override
+  String get errorNetwork => 'Lỗi mạng. Vui lòng kiểm tra kết nối của bạn.';
+
+  @override
+  String get errorUnknown => 'Đã xảy ra lỗi không xác định. Vui lòng thử lại.';
+
+  @override
+  String get errorUnauthorized => 'Bạn không có quyền truy cập. Vui lòng đăng nhập lại.';
+
+  @override
+  String get errorNotFound => 'Không tìm thấy tài nguyên yêu cầu.';
+
+  @override
+  String get errorTimeout => 'Yêu cầu đã hết thời gian. Vui lòng thử lại.';
+
+  @override
+  String get labelLoading => 'Đang tải...';
+
+  @override
+  String get labelNoResults => 'Không tìm thấy kết quả.';
+
+  @override
+  String get labelNoInternet => 'Không có kết nối internet.';
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -382,6 +382,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -520,6 +525,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   io:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,11 @@ dependencies:
   isar_flutter_libs: ^3.1.0+1
   path_provider: ^2.1.5
 
+  # Localization
+  flutter_localizations:
+    sdk: flutter
+  intl: any
+
   # HTTP client
   dio: ^5.0.0
 
@@ -82,6 +87,7 @@ dev_dependencies:
 
 # The following section is specific to Flutter packages.
 flutter:
+  generate: true
 
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in

--- a/specs/issues/2.5-i18n-infrastructure.md
+++ b/specs/issues/2.5-i18n-infrastructure.md
@@ -1,0 +1,113 @@
+## **Status:**
+- Review: Approved
+- PR: Draft
+
+## Metadata
+- **Title:** i18n infrastructure: setup intl package + AppLocalizations + l10n/en.arb + l10n/vi.arb + MaterialApp localizationsDelegates
+- **Phase:** Phase 2 – Core Infrastructure (Shared, Minimal)
+- **GitHub Issue:** #44
+
+---
+
+## Description
+
+Setup hạ tầng đa ngôn ngữ (i18n) cho toàn app — chỉ làm một lần tại phase này, các phase sau chỉ thêm key vào `.arb` file, không refactor lại:
+
+1. **intl + flutter_localizations** — thêm packages vào `pubspec.yaml`, bật `generate: true`
+2. **l10n/en.arb + l10n/vi.arb** — 2 file ARB với skeleton keys ban đầu (app name, common actions, error messages)
+3. **MaterialApp localizationsDelegates** — đăng ký `AppLocalizations.delegate` + `GlobalMaterialLocalizations.delegate` + `GlobalWidgetsLocalizations.delegate`
+4. **l10n.yaml** — cấu hình `arb-dir`, `template-arb-file`, `output-localization-file`
+
+Mục tiêu:
+- Mọi string hiển thị ra UI đều phải qua `AppLocalizations` (không hardcode string)
+- `context.l10n` extension helper để truy cập nhanh từ bất kỳ widget nào
+- Các phase sau chỉ cần thêm key vào `.arb`, chạy `flutter gen-l10n` là xong
+
+---
+
+## Design
+- N/A (infrastructure layer, không có UI riêng)
+
+---
+
+## Acceptance Criteria
+- [ ] `pubspec.yaml` có `flutter_localizations` + `intl`, section `flutter.generate: true`
+- [ ] File `l10n.yaml` ở root với config đúng (`arb-dir: l10n`, `template-arb-file: en.arb`, `output-localization-file: app_localizations.dart`)
+- [ ] `l10n/en.arb` có skeleton keys: app name, common actions (search, cancel, confirm, retry, delete, save), common errors (network error, unknown error, unauthorized)
+- [ ] `l10n/vi.arb` có đủ translations tương ứng với `en.arb`
+- [ ] `MaterialApp` trong `main.dart` / `app.dart` đăng ký đầy đủ `localizationsDelegates` và `supportedLocales: [Locale('en'), Locale('vi')]`
+- [ ] Extension `BuildContext.l10n` tại `lib/core/extensions/l10n_extension.dart` để dùng `context.l10n.someKey`
+- [ ] `flutter gen-l10n` chạy thành công, không có warning
+- [ ] `flutter analyze` — 0 errors/warnings
+
+---
+
+## Implementation Checklist
+
+### `pubspec.yaml`
+- [ ] `[🤖]` Thêm `flutter_localizations` (sdk: flutter) vào `dependencies`
+- [ ] `[🤖]` Thêm `intl: any` vào `dependencies`
+- [ ] `[🤖]` Thêm `flutter: generate: true` vào section `flutter:`
+
+### `l10n.yaml` (root)
+- [ ] `[🤖]` Tạo file với config:
+  ```yaml
+  arb-dir: l10n
+  template-arb-file: en.arb
+  output-localization-file: app_localizations.dart
+  output-dir: lib/l10n
+  nullable-getter: false
+  ```
+
+### `l10n/en.arb`
+- [ ] `[🤖]` Tạo file với skeleton keys:
+  - `appName`: "YMusic"
+  - Common actions: `actionSearch`, `actionCancel`, `actionConfirm`, `actionRetry`, `actionDelete`, `actionSave`, `actionClose`, `actionPlay`, `actionPause`
+  - Common errors: `errorNetwork`, `errorUnknown`, `errorUnauthorized`, `errorNotFound`, `errorTimeout`
+  - Common labels: `labelLoading`, `labelNoResults`, `labelNoInternet`
+
+### `l10n/vi.arb`
+- [ ] `[🤖]` Tạo file với translations tiếng Việt tương ứng đầy đủ cho tất cả keys trong `en.arb`
+
+### `lib/app.dart` (hoặc `main.dart` — nơi khai báo `MaterialApp`)
+- [ ] `[🤖]` Thêm `localizationsDelegates`:
+  ```dart
+  AppLocalizations.delegate,
+  GlobalMaterialLocalizations.delegate,
+  GlobalWidgetsLocalizations.delegate,
+  GlobalCupertinoLocalizations.delegate,
+  ```
+- [ ] `[🤖]` Thêm `supportedLocales: [Locale('en'), Locale('vi')]`
+- [ ] `[🤖]` Thêm `locale` binding với `localeProvider` (Riverpod) để SettingsScreen có thể đổi ngôn ngữ sau (Phase 10.5)
+
+### `lib/core/extensions/l10n_extension.dart`
+- [ ] `[🤖]` Tạo extension:
+  ```dart
+  extension L10nExtension on BuildContext {
+    AppLocalizations get l10n => AppLocalizations.of(this);
+  }
+  ```
+
+### Verify
+- [ ] `[🤖]` Chạy `flutter gen-l10n` — không có lỗi
+- [ ] `[🤖]` Chạy `flutter analyze` — 0 warnings
+
+---
+
+## Notes
+
+- `flutter_localizations` là package trong Flutter SDK — không có version riêng, dùng `sdk: flutter`
+- `intl: any` để tránh version conflict với `flutter_localizations`
+- Generated code nằm tại `.dart_tool/flutter_gen/gen_l10n/` (nếu dùng synthetic package) hoặc `lib/l10n/` (nếu `output-dir` set) — dùng `output-dir: lib/l10n` để dễ kiểm soát
+- `nullable-getter: false` trong `l10n.yaml` để tránh phải null-check mỗi lần dùng `AppLocalizations.of(context)`
+- `localeProvider` (Riverpod `StateProvider<Locale>`) được tạo sẵn để Phase 10.5 (SettingsScreen) chỉ cần `ref.read(localeProvider.notifier).state = Locale('vi')` là đổi ngôn ngữ
+- Các phase sau: chỉ thêm key vào `en.arb` + `vi.arb`, chạy `flutter gen-l10n`, không cần sửa `MaterialApp` hay extension
+- Dependency của: mọi widget hiển thị text (Phase 3.7 AppShell, Phase 3.8 SearchScreen, Phase 3.9 PlayerScreen...)
+- **Không** dùng `context.l10n` trong model/service layer — chỉ dùng trong widget/presentation layer
+
+---
+
+## Screenshots
+| Screen Name | Navigation Steps | Expected State |
+|---|---|---|
+| N/A | N/A | N/A |

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,10 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:ymusic/app.dart';
 
 void main() {
   testWidgets('App renders YMusic placeholder', (WidgetTester tester) async {
-    await tester.pumpWidget(const YMusicApp());
-    expect(find.text('YMusic'), findsOneWidget);
+    await tester.pumpWidget(
+      const ProviderScope(child: YMusicApp()),
+    );
+
+    expect(find.byType(MaterialApp), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- Add `flutter_localizations` + `intl` packages and enable code generation
- Create `l10n/en.arb` + `l10n/vi.arb` with skeleton keys (appName, 9 actions, 5 errors, 3 labels)
- Generate `AppLocalizations` to `lib/l10n/` via `flutter gen-l10n`
- Register full `localizationsDelegates` + `supportedLocales` in `MaterialApp`
- Add `localeProvider` (`StateProvider<Locale>`) for Phase 10.5 language switching
- Create `BuildContext.l10n` extension at `lib/core/extensions/l10n_extension.dart`

## Designs
- N/A (infrastructure layer, no UI)

## Issue
Closes #44