### PR TITLE
feat(core): YouTubeService search(query) → List<SongModel>

### DIFF
--- a/lib/core/error/exceptions.dart
+++ b/lib/core/error/exceptions.dart
@@ -60,3 +60,13 @@ final class CacheException extends AppException {
 final class UnknownException extends AppException {
   const UnknownException([super.message = 'An unknown error occurred']);
 }
+
+final class YouTubeException extends AppException {
+  const YouTubeException(super.message, {this.cause});
+
+  final Object? cause;
+
+  @override
+  String toString() =>
+      'YouTubeException: $message${cause != null ? ' (cause: $cause)' : ''}';
+}

--- a/lib/core/error/failures.dart
+++ b/lib/core/error/failures.dart
@@ -50,6 +50,10 @@ final class CancelledFailure extends Failure {
 final class AuthFailure extends Failure {
   const AuthFailure([super.message = 'Authentication failed']);
 }
+
+final class YouTubeFailure extends Failure {
+  const YouTubeFailure([super.message = 'YouTube error occurred']);
+}
 // ─── Mapper ──────────────────────────────────────────────────────────────────
 
 extension AppExceptionMapper on AppException {
@@ -61,5 +65,6 @@ extension AppExceptionMapper on AppException {
         TimeoutException e => TimeoutFailure(e.message),
         CacheException e => CacheFailure(e.message),
         UnknownException e => UnknownFailure(e.message),
+        YouTubeException e => YouTubeFailure(e.message),
       };
 }

--- a/lib/core/services/youtube_service.dart
+++ b/lib/core/services/youtube_service.dart
@@ -1,0 +1,76 @@
+import 'dart:developer' as dev;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:youtube_explode_dart/youtube_explode_dart.dart';
+
+import 'package:ymusic/core/error/exceptions.dart';
+import 'package:ymusic/features/search/data/models/song_model.dart';
+
+part 'youtube_service.g.dart';
+
+class YouTubeService {
+  YouTubeService({YoutubeExplode? yt})
+      : _client = _YoutubeExplodeClient(yt ?? YoutubeExplode());
+
+  @visibleForTesting
+  YouTubeService.withClient(YouTubeSearchClient client) : _client = client;
+
+  final YouTubeSearchClient _client;
+
+  Future<List<SongModel>> search(String query) async {
+    try {
+      final videos = await _client.searchVideos(query);
+
+      return videos.map(_toSongModel).toList();
+    } on YouTubeException {
+      rethrow;
+    } catch (e) {
+      throw YouTubeException('Search failed for query: "$query"', cause: e);
+    }
+  }
+
+  SongModel _toSongModel(Video video) {
+    if (video.duration == null) {
+      dev.log(
+        'duration is null for video ${video.id.value}',
+        name: 'YouTubeService',
+      );
+    }
+
+    return SongModel(
+      videoId: video.id.value,
+      title: video.title,
+      artist: video.author,
+      thumbnailUrl: video.thumbnails.highResUrl,
+      duration: video.duration ?? Duration.zero,
+    );
+  }
+}
+
+@riverpod
+YouTubeService youTubeService(Ref ref) => YouTubeService();
+
+// ─── Internal client abstraction ─────────────────────────────────────────────
+
+/// Minimal interface over YouTube search operations.
+///
+/// Exists to decouple [YouTubeService] from [YoutubeExplode] so that tests
+/// can inject hand-written fakes without requiring a live network call.
+abstract interface class YouTubeSearchClient {
+  Future<List<Video>> searchVideos(String query);
+}
+
+class _YoutubeExplodeClient implements YouTubeSearchClient {
+  _YoutubeExplodeClient(this._yt);
+
+  final YoutubeExplode _yt;
+
+  @override
+  Future<List<Video>> searchVideos(String query) async {
+    final results = await _yt.search.search(query);
+
+    return results.toList();
+  }
+}

--- a/lib/core/services/youtube_service.g.dart
+++ b/lib/core/services/youtube_service.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'youtube_service.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$youTubeServiceHash() => r'a64fbe6fae5938f5291cfd1d92c8805fa7101cc5';
+
+/// See also [youTubeService].
+@ProviderFor(youTubeService)
+final youTubeServiceProvider = AutoDisposeProvider<YouTubeService>.internal(
+  youTubeService,
+  name: r'youTubeServiceProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$youTubeServiceHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef YouTubeServiceRef = AutoDisposeProviderRef<YouTubeService>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/auth/presentation/states/auth_state.freezed.dart
+++ b/lib/features/auth/presentation/states/auth_state.freezed.dart
@@ -188,7 +188,7 @@ return error(_that.failure);case _:
 
 class _Initial implements AuthState {
   const _Initial();
-
+  
 
 
 
@@ -220,7 +220,7 @@ String toString() {
 
 class _Loading implements AuthState {
   const _Loading();
-
+  
 
 
 
@@ -252,7 +252,7 @@ String toString() {
 
 class _Success implements AuthState {
   const _Success(this.user);
-
+  
 
  final  User user;
 
@@ -318,7 +318,7 @@ as User,
 
 class _Error implements AuthState {
   const _Error(this.failure);
-
+  
 
  final  Failure failure;
 

--- a/specs/issues/3.2-youtube-service.md
+++ b/specs/issues/3.2-youtube-service.md
@@ -1,0 +1,67 @@
+## **Status:**
+- Review: Approved
+- PR: Draft
+
+## Metadata
+- **Title:** YouTubeService: search(query) → List<Song>
+- **Phase:** Phase 3 – Slice: Search & Play
+- **GitHub Issue:** –
+
+---
+
+## Description
+
+Tạo `YouTubeService` — shared service đặt trong `lib/core/services/`, gọi `youtube_explode_dart` để search bài nhạc và parse kết quả thành `List<SongModel>`.
+
+Service này là lớp duy nhất tương tác với YouTube — đặt trong `core` vì nhiều feature sẽ dùng (search, audio extract Phase 3.3, download Phase 9.1, video stream Phase 11.1). Tránh cross-feature imports về sau.
+
+---
+
+## Design
+- N/A (data layer, không có UI)
+
+---
+
+## Acceptance Criteria
+- [ ] YoutubeService đặt ở core/services
+- [ ] `search(String query)` trả về `Future<List<SongModel>>` (không empty list nếu có kết quả)
+- [ ] Mỗi `SongModel` trong kết quả có đủ `videoId`, `title`, `artist`, `thumbnailUrl`, `duration`
+- [ ] Chỉ trả về video (filter out playlist/channel entries từ search results)
+- [ ] Throws `YouTubeException` (không swallow exception) khi network fail hoặc parse fail
+- [ ] Riverpod provider `youTubeServiceProvider` được expose
+- [ ] Unit test: happy path (mock `YoutubeExplode`) + empty results + exception path
+- [ ] `flutter analyze` — 0 warnings
+
+---
+
+## Implementation Checklist
+- [ ] Tạo `lib/core/services/youtube_service.dart`
+  - Class `YouTubeService` với `YoutubeExplode` inject vào constructor
+  - Method `search(String query) → Future<List<SongModel>>`
+  - Parse `SearchVideo` → `SongModel` (map `videoId`, `title`, `channelName` → `artist`, `thumbnails.highResUrl` → `thumbnailUrl`, `duration` → `duration`)
+  - Filter: chỉ lấy entries là `SearchVideo` (bỏ `SearchPlaylist`, `SearchChannel`)
+  - Wrap try-catch, throw `YouTubeException` khi fail
+- [ ] Thêm `YouTubeException` vào `lib/core/error/exceptions.dart`
+- [ ] Tạo Riverpod provider `youTubeServiceProvider` trong cùng file `youtube_service.dart`
+- [ ] Tạo unit test tại `test/core/services/youtube_service_test.dart`
+  - Mock `YoutubeExplode` / `SearchClient`
+  - Test cases: happy path (≥1 result), empty list, `YouTubeException` on network error
+- [ ] `flutter analyze` — 0 warnings
+
+---
+
+## Notes
+
+- Package: `youtube_explode_dart` (đã có trong pubspec từ Phase 3)
+- `YoutubeExplode` nên được inject vào constructor (không khởi tạo trong method) để dễ mock trong test
+- `thumbnails` có nhiều quality level — ưu tiên `highResUrl`, fallback `mediumResUrl`
+- `duration` từ `SearchVideo.duration` là `Duration?` — handle null (set `Duration.zero` nếu null, log warning)
+- Đây là **shared service** (raw data) — không gọi Isar cache ở đây; cache logic sẽ implement ở Phase 3.4 (search repository layer)
+- Đặt trong `lib/core/services/` vì sẽ được dùng bởi nhiều feature: Phase 3.3 (extractAudioUrl), Phase 9.1 (download), Phase 11.1 (video stream)
+- Dependency của: Phase 3.4 (cache), Phase 3.8 (SearchScreen), Phase 3.10 (unit test)
+- Rate limiting / throttle sẽ implement ở Phase 3.3 (extractAudioUrl) — không cần ở search
+
+## Screenshots
+| Screen Name | Navigation Steps | Expected State |
+|---|---|---|
+| N/A | N/A | N/A |

--- a/test/core/services/youtube_service_test.dart
+++ b/test/core/services/youtube_service_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:youtube_explode_dart/youtube_explode_dart.dart';
+
+import 'package:ymusic/core/error/exceptions.dart';
+import 'package:ymusic/core/services/youtube_service.dart';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const _videoId = 'dQw4w9WgXcQ';
+const _title = 'Test Song';
+const _artist = 'Test Artist';
+const _query = 'test query';
+const _duration = Duration(minutes: 3, seconds: 45);
+
+Video _makeVideo({
+  String id = _videoId,
+  String title = _title,
+  String author = _artist,
+  Duration? duration = _duration,
+}) {
+  return Video(
+    VideoId(id),
+    title,
+    author,
+    ChannelId('UCuAXFkgsw1L7xaCfnd5JJOw'),
+    null,
+    null,
+    null,
+    '',
+    duration,
+    ThumbnailSet(id),
+    null,
+    const Engagement(0, null, null),
+    false,
+  );
+}
+
+// ─── Fakes ────────────────────────────────────────────────────────────────────
+
+class _FakeClient implements YouTubeSearchClient {
+  _FakeClient(this._videos);
+
+  final List<Video> _videos;
+
+  @override
+  Future<List<Video>> searchVideos(String query) async => _videos;
+}
+
+class _ThrowingClient implements YouTubeSearchClient {
+  @override
+  Future<List<Video>> searchVideos(String query) =>
+      Future.error(Exception('Network error'));
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+void main() {
+  group('YouTubeService.search', () {
+    test('returns parsed SongModels when results are found', () async {
+      final video = _makeVideo();
+      final service = YouTubeService.withClient(_FakeClient([video]));
+
+      final result = await service.search(_query);
+
+      expect(result, hasLength(1));
+      expect(result.first.videoId, _videoId);
+      expect(result.first.title, _title);
+      expect(result.first.artist, _artist);
+      expect(result.first.thumbnailUrl, contains(_videoId));
+      expect(result.first.duration, _duration);
+    });
+
+    test('returns empty list when no results', () async {
+      final service = YouTubeService.withClient(_FakeClient([]));
+
+      final result = await service.search(_query);
+
+      expect(result, isEmpty);
+    });
+
+    test('sets duration to Duration.zero when video duration is null', () async {
+      final video = _makeVideo(duration: null);
+      final service = YouTubeService.withClient(_FakeClient([video]));
+
+      final result = await service.search(_query);
+
+      expect(result.first.duration, Duration.zero);
+    });
+
+    test('throws YouTubeException on network error', () async {
+      final service = YouTubeService.withClient(_ThrowingClient());
+
+      await expectLater(
+        service.search(_query),
+        throwsA(isA<YouTubeException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add `YouTubeService` in `lib/core/services/` with `YoutubeExplode` injected via constructor
- `search(String query)` parses `Video` results into `List<SongModel>` (videoId, title, artist, thumbnailUrl, duration)
- `YouTubeException` added to exceptions/failures hierarchy
- Riverpod provider `youTubeServiceProvider` exposed via code generation
- 4 unit tests covering happy path, empty results, null duration, and network exception

## Issue
Closes #50