### PR TITLE
feat: add mini player bar and implement full player screen UI

### DIFF
--- a/lib/core/constants/app_colors.dart
+++ b/lib/core/constants/app_colors.dart
@@ -16,6 +16,7 @@ class AppColors {
   static const Color text = Color(0xFFFFFFFF);
   static const Color textSecondary = Color(0xFFAAAAAA);
   static const Color subtext = Color(0xFF717171);
+  static const Color dark = Color(0XFF1C1C1E);
 
   // Dark — Utility
   static const Color divider = Color(0xFF2A2A2A);

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -100,9 +100,10 @@ GoRouter router(Ref ref) {
         ],
       ),
 
-      /// Full Player Screen (push over shell)
+      /// Full Player Screen (push over shell — covers BottomNav)
       GoRoute(
         path: AppRoutes.player,
+        name: AppRoutes.player,
         builder: (context, state) {
           final videoId = state.uri.queryParameters['videoId'];
           return FullPlayerScreen(videoId: videoId);

--- a/lib/features/home/presentation/screens/app_shell.dart
+++ b/lib/features/home/presentation/screens/app_shell.dart
@@ -5,20 +5,14 @@ import 'package:ymusic/core/constants/app_spacing.dart';
 import 'package:ymusic/core/constants/app_strings.dart';
 import 'package:ymusic/core/constants/app_typography.dart';
 import 'package:ymusic/core/router/app_router.dart';
+import 'package:ymusic/features/player/presentation/widgets/mini_player_bar.dart';
 
-enum _NavTab {
-  home,
-  search,
-  library,
-}
+enum _NavTab { home, search, library }
 
 class AppShell extends StatefulWidget {
   final Widget child;
 
-  const AppShell({
-    required this.child,
-    super.key,
-  });
+  const AppShell({required this.child, super.key});
 
   @override
   State<AppShell> createState() => _AppShellState();
@@ -68,30 +62,38 @@ class _AppShellState extends State<AppShell> {
             ),
           ),
         ),
-        padding: const EdgeInsets.only(
-          bottom: _navBarPaddingBottom,
-          top: _navBarPaddingTop,
-        ),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceAround,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
           children: [
-            _buildTabItem(
-              icon: Icons.home,
-              label: AppStrings.navHome,
-              isActive: selectedTab == _NavTab.home,
-              onTap: () => _onTabTapped(_NavTab.home),
+            const MiniPlayerBar(),
+            Padding(
+              padding: const EdgeInsets.only(
+                top: _navBarPaddingTop,
+                bottom: _navBarPaddingBottom,
+              ),
+              child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                _buildTabItem(
+                  icon: Icons.home,
+                  label: AppStrings.navHome,
+                  isActive: selectedTab == _NavTab.home,
+                  onTap: () => _onTabTapped(_NavTab.home),
+                ),
+                _buildTabItem(
+                  icon: Icons.search,
+                  label: AppStrings.navSearch,
+                  isActive: selectedTab == _NavTab.search,
+                  onTap: () => _onTabTapped(_NavTab.search),
+                ),
+                _buildTabItem(
+                  icon: Icons.library_music,
+                  label: AppStrings.navLibrary,
+                  isActive: selectedTab == _NavTab.library,
+                  onTap: () => _onTabTapped(_NavTab.library),
+                ),
+              ],
             ),
-            _buildTabItem(
-              icon: Icons.search,
-              label: AppStrings.navSearch,
-              isActive: selectedTab == _NavTab.search,
-              onTap: () => _onTabTapped(_NavTab.search),
-            ),
-            _buildTabItem(
-              icon: Icons.library_music,
-              label: AppStrings.navLibrary,
-              isActive: selectedTab == _NavTab.library,
-              onTap: () => _onTabTapped(_NavTab.library),
             ),
           ],
         ),

--- a/lib/features/player/presentation/screens/full_player_screen.dart
+++ b/lib/features/player/presentation/screens/full_player_screen.dart
@@ -1,19 +1,129 @@
 import 'package:flutter/material.dart';
+import 'package:ymusic/core/constants/app_colors.dart';
+import 'package:ymusic/core/constants/app_spacing.dart';
+import 'package:ymusic/core/constants/app_typography.dart';
+import 'package:ymusic/features/player/presentation/strings/player_strings.dart';
+import 'package:ymusic/features/player/presentation/widgets/player_artwork.dart';
+import 'package:ymusic/features/player/presentation/widgets/player_controls.dart';
+import 'package:ymusic/features/player/presentation/widgets/player_secondary_controls.dart';
+import 'package:ymusic/features/player/presentation/widgets/player_seek_bar.dart';
+import 'package:ymusic/features/search/data/models/song_model.dart';
+
+// TODO(3.8): Replace with playerStateProvider
+const _mockSong = SongModel(
+  videoId: 'dQw4w9WgXcQ',
+  title: 'Never Gonna Give You Up',
+  artist: 'Rick Astley',
+  thumbnailUrl: 'https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg',
+  duration: Duration(minutes: 3, seconds: 33),
+);
+
+const _mockProgress = 0.3;
+const _mockCurrentTime = '1:00';
+const _mockTotalTime = '3:33';
 
 class FullPlayerScreen extends StatelessWidget {
   final String? videoId;
 
-  const FullPlayerScreen({
-    this.videoId,
-    super.key,
-  });
+  const FullPlayerScreen({this.videoId, super.key});
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Player')),
-      body: Center(
-        child: Text('Full Player Screen${videoId != null ? '\nVideo ID: $videoId' : ''}'),
+      backgroundColor: AppColors.background,
+      body: Stack(
+        children: [
+          // Full-screen blur background with centered artwork
+          PlayerArtwork(thumbnailUrl: _mockSong.thumbnailUrl),
+
+          // Content overlay
+          const SafeArea(
+            child: Column(
+              children: [
+                _TopNav(),
+                Spacer(),
+                _SongInfo(),
+                PlayerSeekBar(
+                  value: _mockProgress,
+                  currentTime: _mockCurrentTime,
+                  totalTime: _mockTotalTime,
+                ),
+                SizedBox(height: AppSpacing.sm),
+                PlayerControls(),
+                SizedBox(height: AppSpacing.sm),
+                PlayerSecondaryControls(),
+                SizedBox(height: AppSpacing.md),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TopNav extends StatelessWidget {
+  const _TopNav();
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          IconButton(
+            onPressed: () => Navigator.of(context).pop(),
+            icon: const Icon(
+              Icons.keyboard_arrow_down,
+              color: AppColors.icon,
+              size: AppSpacing.xl,
+            ),
+          ),
+          const Text(PlayerStrings.nowPlaying, style: AppTypography.body),
+          IconButton(
+            onPressed: () {},
+            icon: const Icon(Icons.more_horiz, color: AppColors.icon),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SongInfo extends StatelessWidget {
+  const _SongInfo();
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.md,
+        vertical: AppSpacing.sm,
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  _mockSong.title,
+                  style: AppTypography.h2,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: AppSpacing.xs),
+                Text(
+                  _mockSong.artist,
+                  style: AppTypography.body.copyWith(
+                    color: AppColors.textSecondary,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/player/presentation/strings/player_strings.dart
+++ b/lib/features/player/presentation/strings/player_strings.dart
@@ -1,0 +1,6 @@
+class PlayerStrings {
+  PlayerStrings._();
+
+  static const nowPlaying = 'Now Playing';
+  static const queue = 'Queue';
+}

--- a/lib/features/player/presentation/widgets/mini_player_bar.dart
+++ b/lib/features/player/presentation/widgets/mini_player_bar.dart
@@ -1,0 +1,105 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:ymusic/core/constants/app_colors.dart';
+import 'package:ymusic/core/constants/app_spacing.dart';
+import 'package:ymusic/core/constants/app_typography.dart';
+import 'package:ymusic/core/router/app_router.dart';
+import 'package:ymusic/features/search/data/models/song_model.dart';
+
+// TODO(3.8): Replace with playerStateProvider
+const _mockSong = SongModel(
+  videoId: 'dQw4w9WgXcQ',
+  title: 'Never Gonna Give You Up',
+  artist: 'Rick Astley',
+  thumbnailUrl: 'https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg',
+  duration: Duration(minutes: 3, seconds: 33),
+);
+
+const double _thumbnailSize = 48;
+const double _thumbnailBorderRadius = 6;
+const double _barHeight = 68;
+
+class MiniPlayerBar extends StatefulWidget {
+  const MiniPlayerBar({super.key});
+
+  @override
+  State<MiniPlayerBar> createState() => _MiniPlayerBarState();
+}
+
+class _MiniPlayerBarState extends State<MiniPlayerBar> {
+  // TODO(3.8): Replace with playerStateProvider
+  bool _isPlaying = true;
+  bool _hasSong = true;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_hasSong) return const SizedBox.shrink();
+
+    final thumbnailUrl = _mockSong.thumbnailUrl;
+    final isValidUrl = Uri.tryParse(thumbnailUrl)?.hasAuthority ?? false;
+
+    return GestureDetector(
+      onTap: () => context.pushNamed(AppRoutes.player),
+      child: ColoredBox(
+        color: AppColors.surface,
+        child: SizedBox(
+          height: _barHeight,
+          child: Row(
+            children: [
+              const SizedBox(width: AppSpacing.sm),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(_thumbnailBorderRadius),
+                child: SizedBox(
+                  width: _thumbnailSize,
+                  height: _thumbnailSize,
+                  child: isValidUrl
+                      ? CachedNetworkImage(
+                          imageUrl: thumbnailUrl,
+                          fit: BoxFit.cover,
+                        )
+                      : const ColoredBox(
+                          color: AppColors.surfaceVariant,
+                          child: Icon(Icons.music_note, color: AppColors.iconMuted),
+                        ),
+                ),
+              ),
+              const SizedBox(width: AppSpacing.sm),
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      _mockSong.title,
+                      style: AppTypography.body,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    Text(
+                      _mockSong.artist,
+                      style: AppTypography.caption,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+              IconButton(
+                onPressed: () => setState(() => _isPlaying = !_isPlaying),
+                icon: Icon(
+                  _isPlaying ? Icons.pause_circle : Icons.play_circle,
+                  color: AppColors.icon,
+                ),
+              ),
+              IconButton(
+                onPressed: () => setState(() => _hasSong = false),
+                icon: const Icon(Icons.close, color: AppColors.icon),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/player/presentation/widgets/player_artwork.dart
+++ b/lib/features/player/presentation/widgets/player_artwork.dart
@@ -1,0 +1,86 @@
+import 'dart:ui';
+
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:ymusic/core/constants/app_colors.dart';
+
+const double _artworkBorderRadius = 16;
+const double _artworkWidthFraction = 0.80;
+const double _overlayOpacity = 0.55;
+const double _blurSigma = 20;
+const double _shadowAlpha = 0.4;
+const double _shadowBlurRadius = 32;
+const double _shadowOffsetY = 12;
+const double _placeholderIconSize = 64;
+
+class PlayerArtwork extends StatelessWidget {
+  final String thumbnailUrl;
+
+  const PlayerArtwork({super.key, required this.thumbnailUrl});
+
+  @override
+  Widget build(BuildContext context) {
+    final isValidUrl = Uri.tryParse(thumbnailUrl)?.hasAuthority ?? false;
+
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        // Blurred background
+        if (isValidUrl)
+          ImageFiltered(
+            imageFilter: ImageFilter.blur(sigmaX: _blurSigma, sigmaY: _blurSigma),
+            child: CachedNetworkImage(
+              imageUrl: thumbnailUrl,
+              fit: BoxFit.cover,
+            ),
+          )
+        else
+          const ColoredBox(color: AppColors.background),
+
+        // Dark overlay
+        const ColoredBox(color: Color.fromRGBO(0, 0, 0, _overlayOpacity)),
+
+        // Foreground artwork (centered, 80% width, rounded, shadow)
+        Center(
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final size = constraints.maxWidth * _artworkWidthFraction;
+              return Container(
+                width: size,
+                height: size,
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(_artworkBorderRadius),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withValues(alpha: _shadowAlpha),
+                      blurRadius: _shadowBlurRadius,
+                      offset: const Offset(0, _shadowOffsetY),
+                    ),
+                  ],
+                ),
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(_artworkBorderRadius),
+                  child: isValidUrl
+                      ? CachedNetworkImage(
+                          imageUrl: thumbnailUrl,
+                          width: size,
+                          height: size,
+                          fit: BoxFit.cover,
+                        )
+                      : const ColoredBox(
+                          color: AppColors.surfaceVariant,
+                          child: Icon(
+                            Icons.music_note,
+                            size: _placeholderIconSize,
+                            color: AppColors.iconMuted,
+                          ),
+                        ),
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/player/presentation/widgets/player_controls.dart
+++ b/lib/features/player/presentation/widgets/player_controls.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:ymusic/core/constants/app_colors.dart';
+
+const double _playButtonSize = 64;
+const double _controlIconSize = 32;
+
+class PlayerControls extends StatefulWidget {
+  const PlayerControls({super.key});
+
+  @override
+  State<PlayerControls> createState() => _PlayerControlsState();
+}
+
+class _PlayerControlsState extends State<PlayerControls> {
+  // TODO(3.8): Replace with playerStateProvider
+  bool _isPlaying = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      children: [
+        IconButton(
+          onPressed: () {}, // TODO(3.8): Wire prev to AudioPlayerService
+          icon: const Icon(
+            Icons.skip_previous,
+            size: _controlIconSize,
+            color: AppColors.icon,
+          ),
+        ),
+        GestureDetector(
+          onTap: () => setState(() => _isPlaying = !_isPlaying),
+          child: Container(
+            width: _playButtonSize,
+            height: _playButtonSize,
+            decoration: BoxDecoration(
+              color: AppColors.loginGlowPurple,
+              shape: BoxShape.circle,
+              boxShadow: [
+                BoxShadow(
+                  color: AppColors.loginGlowPurple.withValues(alpha: 0.5),
+                  blurRadius: 24,
+                  offset: const Offset(0, 8),
+                ),
+              ],
+            ),
+            child: Icon(
+              _isPlaying ? Icons.pause : Icons.play_arrow,
+              size: _controlIconSize,
+              color: AppColors.onPrimary,
+            ),
+          ),
+        ),
+        IconButton(
+          onPressed: () {}, // TODO(3.8): Wire next to AudioPlayerService
+          icon: const Icon(
+            Icons.skip_next,
+            size: _controlIconSize,
+            color: AppColors.icon,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/player/presentation/widgets/player_secondary_controls.dart
+++ b/lib/features/player/presentation/widgets/player_secondary_controls.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:ymusic/core/constants/app_colors.dart';
+import 'package:ymusic/core/constants/app_spacing.dart';
+
+const double _secondaryIconSize = 22;
+
+enum _RepeatMode { off, one, all }
+
+class PlayerSecondaryControls extends StatefulWidget {
+  const PlayerSecondaryControls({super.key});
+
+  @override
+  State<PlayerSecondaryControls> createState() => _PlayerSecondaryControlsState();
+}
+
+class _PlayerSecondaryControlsState extends State<PlayerSecondaryControls> {
+  // TODO(3.8): Replace with playerStateProvider
+  bool _shuffleActive = false;
+  _RepeatMode _repeatMode = _RepeatMode.off;
+  bool _liked = false;
+
+  void _cycleRepeat() {
+    setState(() {
+      _repeatMode = switch (_repeatMode) {
+        _RepeatMode.off => _RepeatMode.one,
+        _RepeatMode.one => _RepeatMode.all,
+        _RepeatMode.all => _RepeatMode.off,
+      };
+    });
+  }
+
+  IconData get _repeatIcon => switch (_repeatMode) {
+        _RepeatMode.one => Icons.repeat_one,
+        _ => Icons.repeat,
+      };
+
+  Color _activeColor(bool active) =>
+      active ? AppColors.loginGlowPurple : AppColors.iconMuted;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xl),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          IconButton(
+            onPressed: () => setState(() => _shuffleActive = !_shuffleActive),
+            icon: Icon(
+              Icons.shuffle,
+              size: _secondaryIconSize,
+              color: _activeColor(_shuffleActive),
+            ),
+          ),
+          IconButton(
+            onPressed: _cycleRepeat,
+            icon: Icon(
+              _repeatIcon,
+              size: _secondaryIconSize,
+              color: _activeColor(_repeatMode != _RepeatMode.off),
+            ),
+          ),
+          IconButton(
+            onPressed: () => setState(() => _liked = !_liked),
+            icon: Icon(
+              _liked ? Icons.favorite : Icons.favorite_border,
+              size: _secondaryIconSize,
+              color: _liked ? AppColors.primary : AppColors.iconMuted,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/player/presentation/widgets/player_seek_bar.dart
+++ b/lib/features/player/presentation/widgets/player_seek_bar.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:ymusic/core/constants/app_colors.dart';
+import 'package:ymusic/core/constants/app_spacing.dart';
+import 'package:ymusic/core/constants/app_typography.dart';
+
+const double _inactiveTrackAlpha = 0.15;
+const double _overlayAlpha = 0.2;
+const double _trackHeight = 3;
+const double _thumbRadius = 6;
+
+class PlayerSeekBar extends StatefulWidget {
+  final double value;
+  final String currentTime;
+  final String totalTime;
+  final ValueChanged<double>? onChanged;
+
+  const PlayerSeekBar({
+    super.key,
+    required this.value,
+    required this.currentTime,
+    required this.totalTime,
+    this.onChanged,
+  });
+
+  @override
+  State<PlayerSeekBar> createState() => _PlayerSeekBarState();
+}
+
+class _PlayerSeekBarState extends State<PlayerSeekBar> {
+  late double _current;
+
+  @override
+  void initState() {
+    super.initState();
+    _current = widget.value;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        SliderTheme(
+          data: SliderTheme.of(context).copyWith(
+            activeTrackColor: AppColors.loginGlowPurple,
+            inactiveTrackColor: Colors.white.withValues(alpha: _inactiveTrackAlpha),
+            thumbColor: Colors.white,
+            overlayColor: AppColors.loginGlowPurple.withValues(alpha: _overlayAlpha),
+            trackHeight: _trackHeight,
+            thumbShape: const RoundSliderThumbShape(enabledThumbRadius: _thumbRadius),
+          ),
+          child: Slider(
+            value: _current,
+            min: 0,
+            max: 1,
+            onChanged: (v) {
+              setState(() => _current = v);
+              widget.onChanged?.call(v); // TODO(3.8): Wire to AudioPlayerService
+            },
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(widget.currentTime, style: AppTypography.label),
+              Text(widget.totalTime, style: AppTypography.label),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/specs/issues/3.6-mini-player-bar-full-player-screen.md
+++ b/specs/issues/3.6-mini-player-bar-full-player-screen.md
@@ -1,0 +1,275 @@
+## **Status:**
+- Review: Approved
+- PR: Todo
+
+## Metadata
+- **Title:** MiniPlayerBar + FullPlayerScreen (art, seek slider, controls, blur bg — hardcoded state trước)
+- **Phase:** Phase 3 – Slice: Search & Play
+- **GitHub Issue:** #57
+- **Owner:** `[🤖]`
+
+---
+
+## Description
+
+Implement 2 UI components cốt lõi của player:
+
+1. **MiniPlayerBar** — thanh player nhỏ xuất hiện phía trên BottomNav khi có bài đang phát; tap để mở FullPlayerScreen
+2. **FullPlayerScreen** — màn hình player đầy đủ với artwork, seek slider, controls (play/pause, prev, next, shuffle, repeat), và blur background
+
+Cả hai dùng **hardcoded state** (static `SongModel` giả), chưa kết nối `AudioPlayerService` hay `playerStateProvider` (sẽ wire ở Phase 3.8–3.9).
+
+---
+
+## Design
+
+- Không có file design riêng cho task này
+- Follow YouTube Music player pattern:
+  - **MiniPlayerBar:** thumbnail + title + artist + play/pause button + close button; luôn visible ở bottom khi có song
+  - **FullPlayerScreen:** artwork to (vuông, bo góc) ở giữa + title/artist + seek slider + time labels + controls row + shuffle/repeat row
+
+---
+
+## Acceptance Criteria
+
+### MiniPlayerBar
+- [ ] `MiniPlayerBar` hiển thị phía trên `BottomNavigationBar` trong `AppShell` khi `_hasSong = true` (hardcoded)
+- [ ] Hiển thị: thumbnail (via `cached_network_image`), song title, artist name, play/pause icon button, close button
+- [ ] Tap vào bar (ngoài buttons) → navigate tới `FullPlayerScreen` (push route, không replace)
+- [ ] Play/pause button toggle icon (hardcoded `_isPlaying` local state)
+- [ ] Close button → ẩn `MiniPlayerBar` (set `_hasSong = false` hoặc navigate away)
+- [ ] Height cố định ~64–72dp, background `AppColors.surface` (hoặc dark card)
+- [ ] Không hiện khi không có song (`_hasSong = false`)
+
+### FullPlayerScreen
+- [ ] Artwork: `CachedNetworkImage` hình vuông bo góc, chiếm ~40–45% chiều cao màn hình
+- [ ] Blur background: artwork thumbnail làm background blur (dùng `ImageFilter.blur` hoặc `BackdropFilter`), overlay tối mờ
+- [ ] Title + artist: hiển thị bên dưới artwork, title bold, artist muted; ellipsis nếu quá dài
+- [ ] Seek slider: `Slider` với `value` hardcoded (ví dụ 0.3), `min: 0`, `max: 1`; kéo được (callback no-op tạm)
+- [ ] Time labels: current time (ví dụ "1:12") bên trái, total duration (ví dụ "3:45") bên phải
+- [ ] Controls row: Prev (`Icons.skip_previous`), Play/Pause toggle, Next (`Icons.skip_next`) — đều tap được, play/pause toggle icon
+- [ ] Shuffle button: `Icons.shuffle` — tap toggle active/inactive state (hardcoded)
+- [ ] Repeat button: `Icons.repeat` — tap cycle qua Off → One → All (hardcoded local state)
+- [ ] Like button: `Icons.favorite_border` / `Icons.favorite` — toggle (hardcoded)
+- [ ] Swipe-down hoặc back button → dismiss `FullPlayerScreen` (pop)
+- [ ] `flutter analyze` — 0 warnings
+
+---
+
+## Implementation Checklist
+
+### 1. File Structure
+
+```
+lib/features/player/
+└── presentation/
+    ├── screens/
+    │   └── full_player_screen.dart
+    ├── widgets/
+    │   ├── mini_player_bar.dart
+    │   ├── player_artwork.dart          # artwork + blur background
+    │   ├── player_controls.dart         # prev/play/next row
+    │   ├── player_seek_bar.dart         # slider + time labels
+    │   └── player_secondary_controls.dart  # shuffle, repeat, like
+    └── strings/
+        └── player_strings.dart
+```
+
+### 2. Router — thêm FullPlayerScreen route
+
+Trong `lib/core/router/app_router.dart`, thêm route `/player`:
+
+```dart
+GoRoute(
+  path: '/player',
+  name: AppRoutes.player,
+  builder: (context, state) => const FullPlayerScreen(),
+),
+```
+
+Thêm constant `player` vào `AppRoutes`.
+
+### 3. MiniPlayerBar — `lib/features/player/presentation/widgets/mini_player_bar.dart`
+
+```dart
+class MiniPlayerBar extends StatefulWidget {
+  const MiniPlayerBar({super.key});
+}
+```
+
+- Hardcoded song data (dùng `SongModel` với videoId/title/artist/thumbnailUrl giả)
+- Hardcoded `_isPlaying = true`
+- `GestureDetector` bao ngoài → `context.pushNamed(AppRoutes.player)`
+- `IconButton` play/pause toggle local `setState`
+- `IconButton` close → gọi callback hoặc set `_hasSong = false` (tuỳ integration với AppShell)
+
+Layout:
+```
+Row
+  ├── CachedNetworkImage (48x48, rounded)
+  ├── Expanded → Column(title, artist)
+  ├── IconButton(play/pause)
+  └── IconButton(close)
+```
+
+### 4. Tích hợp MiniPlayerBar vào AppShell
+
+Trong `lib/features/home/presentation/screens/app_shell.dart` (hoặc `shell_screen.dart`):
+
+```dart
+// Dùng Stack + Positioned hoặc Column để đặt MiniPlayerBar phía trên BottomNav
+Stack(
+  children: [
+    child, // body content
+    Positioned(
+      bottom: kBottomNavigationBarHeight,
+      left: 0,
+      right: 0,
+      child: MiniPlayerBar(),
+    ),
+  ],
+)
+```
+
+Hoặc dùng `Column` với `Expanded` cho body và `MiniPlayerBar` + `BottomNavigationBar` xếp dọc.
+
+### 5. PlayerArtwork — `lib/features/player/presentation/widgets/player_artwork.dart`
+
+```dart
+class PlayerArtwork extends StatelessWidget {
+  final String thumbnailUrl;
+  const PlayerArtwork({super.key, required this.thumbnailUrl});
+}
+```
+
+- `Stack`:
+  - Background: `ImageFiltered` / `BackdropFilter` với `ImageFilter.blur(sigmaX: 20, sigmaY: 20)` lên thumbnail
+  - Overlay: `Container` màu đen opacity 0.5
+  - Foreground: `CachedNetworkImage` hình vuông bo góc 16dp, shadow nhẹ
+
+### 6. PlayerSeekBar — `lib/features/player/presentation/widgets/player_seek_bar.dart`
+
+```dart
+class PlayerSeekBar extends StatefulWidget {
+  final double value;        // 0.0 → 1.0
+  final String currentTime;  // "1:12"
+  final String totalTime;    // "3:45"
+  final ValueChanged<double>? onChanged; // no-op tạm
+}
+```
+
+- `Slider` với `activeColor: AppColors.primary`
+- Row bên dưới: `Text(currentTime)` + `Spacer` + `Text(totalTime)`
+
+### 7. PlayerControls — `lib/features/player/presentation/widgets/player_controls.dart`
+
+```dart
+class PlayerControls extends StatefulWidget {
+  const PlayerControls({super.key});
+}
+```
+
+- Row: `IconButton(skip_previous)`, `IconButton(play_circle / pause_circle, size 64)`, `IconButton(skip_next)`
+- Play/pause toggle local `_isPlaying` state
+- Prev/Next `onPressed` → no-op (print log hoặc empty lambda)
+
+### 8. PlayerSecondaryControls — shuffle, repeat, like
+
+```dart
+class PlayerSecondaryControls extends StatefulWidget {
+  const PlayerSecondaryControls({super.key});
+}
+```
+
+- Row: shuffle icon, `Spacer`, repeat icon, `Spacer`, like icon
+- Shuffle: toggle active (màu primary vs muted)
+- Repeat: cycle `RepeatMode` enum: `off → one → all` (local state)
+- Like: toggle `Icons.favorite_border / Icons.favorite`
+
+### 9. FullPlayerScreen layout
+
+```dart
+class FullPlayerScreen extends StatelessWidget {
+  const FullPlayerScreen({super.key});
+}
+```
+
+```
+Stack
+├── PlayerArtwork (full screen background)
+└── SafeArea → Column
+    ├── AppBar (transparent, back button)
+    ├── Spacer
+    ├── PlayerArtwork foreground (artwork image, 80% width)
+    ├── SizedBox(height: AppSpacing.lg)
+    ├── Row(title+artist, like button)
+    ├── PlayerSeekBar
+    ├── PlayerControls
+    ├── PlayerSecondaryControls
+    └── SizedBox(height: AppSpacing.md)
+```
+
+### 10. Hardcoded data
+
+Tạo constant trong file hoặc dùng trực tiếp:
+
+```dart
+// TODO(3.8): Replace with playerStateProvider
+const _mockSong = SongModel(
+  videoId: 'dQw4w9WgXcQ',
+  title: 'Never Gonna Give You Up',
+  artist: 'Rick Astley',
+  thumbnailUrl: 'https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg',
+  duration: Duration(minutes: 3, seconds: 33),
+);
+const _mockProgress = 0.3;
+const _mockCurrentTime = '1:00';
+const _mockTotalTime = '3:33';
+```
+
+### 11. PlayerStrings
+
+```dart
+// lib/features/player/presentation/strings/player_strings.dart
+class PlayerStrings {
+  static const nowPlaying = 'Now Playing';
+  static const queue = 'Queue';
+}
+```
+
+### 12. Checklist cuối
+
+- [ ] `MiniPlayerBar` visible trong `AppShell` (hardcoded `_hasSong = true`)
+- [ ] Tap `MiniPlayerBar` → mở `FullPlayerScreen`
+- [ ] `FullPlayerScreen` có đủ artwork, seek bar, controls, secondary controls
+- [ ] Blur background hoạt động (không crash trên iOS simulator)
+- [ ] Tất cả `TODO(3.8)` comment đánh dấu chỗ sẽ wire provider
+- [ ] `const` constructors đầy đủ
+- [ ] `flutter analyze` — 0 warnings
+
+---
+
+## Notes
+
+- **Hardcoded state hoàn toàn** — không import `AudioPlayerService`, không gọi `ref.watch` bất kỳ player provider nào
+- `TODO(3.8)` comment mỗi chỗ sẽ replace bằng real state để Phase 3.8 dễ tìm
+- Blur background dùng `ImageFilter.blur` qua `BackdropFilter` hoặc `ImageFiltered` widget — cần test trên iOS simulator (đôi khi render khác Android)
+- `FullPlayerScreen` được push (không replace) để swipe-back / back button hoạt động tự nhiên
+- Phase 4.1 sẽ thêm Hero animation và DraggableScrollableSheet animation giữa mini và full player — thiết kế widget tách biệt để dễ wrap Hero sau
+- `MiniPlayerBar` integration vào `AppShell`: nếu AppShell đang dùng `ShellRoute` của go_router, đặt `MiniPlayerBar` trong `builder` của `ShellRoute`
+
+---
+
+## Screenshots
+
+| Screen | Navigation | Expected |
+|---|---|---|
+| AppShell + MiniPlayerBar | Launch app | MiniPlayerBar visible phía trên BottomNav |
+| MiniPlayerBar play/pause | Tap play icon | Icon toggle play ↔ pause |
+| MiniPlayerBar → FullPlayer | Tap bar | FullPlayerScreen mở, artwork hiển thị |
+| FullPlayer controls | Tap prev/play/next | play/pause toggle, prev/next no-op |
+| FullPlayer seek | Drag slider | Slider di chuyển, callback no-op |
+| FullPlayer shuffle | Tap shuffle | Icon active/inactive toggle |
+| FullPlayer repeat | Tap repeat (3 lần) | Off → One → All cycle |
+| FullPlayer like | Tap like | Icon outline ↔ filled |
+| FullPlayer dismiss | Swipe down / back | Pop về màn hình trước |

--- a/specs/story.md
+++ b/specs/story.md
@@ -60,7 +60,7 @@ Packages: youtube_explode_dart, just_audio, cached_network_image
 - [x] 3.2 – YouTubeDatasource: search(query) → List<Song> (parse từ youtube_explode_dart). `[🤖]`
 - [x] 3.3 – extractAudioUrl(videoId) + fallback + rate limiting (queue + throttle 1 req/s). `[👤]` *(stream handling + rate limiting logic)*
 - [x] 3.4 – AppShell + BottomNav (Home/Search/Library) + SongTile widget (hardcoded Song data). `[🤖]`
-- [ ] 3.5 – SearchScreen: debounce 500ms + autocomplete suggestions + results list (wire tới YouTubeDatasource 3.2); play action là no-op tạm. `[🤖]`
+- [x] 3.5 – SearchScreen: debounce 500ms + autocomplete suggestions + results list (wire tới YouTubeDatasource 3.2); play action là no-op tạm. `[🤖]`
 - [ ] 3.5.1 – SearchScreen browse view (initial state, Spotify-style): "Picked for you" horizontal shelf + "Discover something new" horizontal shelf (cả hai fetch từ YouTube) + "Browse by category" 2-col grid (Pop, Rock, Hip-Hop, K-Pop, Electronic, R&B, Jazz, Classical, Latin, Indie); tap category → trigger search. `[🤖]`
 - [ ] 3.6 – MiniPlayerBar + FullPlayerScreen (art, seek slider, controls, blur bg — hardcoded state trước). `[🤖]`
 - [ ] 3.7 – AudioPlayerService: just_audio instance + play/pause/seek/next/prev. `[👤]` *(stream handling)*


### PR DESCRIPTION
- Add MiniPlayerBar above bottom nav with thumbnail, play/pause, close
- Implement FullPlayerScreen with blurred artwork background and controls
- Extract player UI into PlayerArtwork, PlayerControls, PlayerSeekBar, PlayerSecondaryControls widgets
- Add named route for player to support pushNamed navigation
- Add AppColors.dark and PlayerStrings constants